### PR TITLE
Damn.pm - remove symbol import from DynaLoader use statement

### DIFF
--- a/Damn.pm
+++ b/Damn.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 use Exporter;
-use DynaLoader  qw( AUTOLOAD );
+use DynaLoader;
 
 use vars qw( $VERSION @ISA @EXPORT @EXPORT_OK );
 


### PR DESCRIPTION
DynaLoader doesn't export anything. This causes errors in 5.39.1:

    Attempt to call undefined import method with arguments via
    package "DynaLoader" (Perhaps you forgot to load the package?)